### PR TITLE
Feature/rate limiter

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,3 +86,7 @@ func main() {
 // go run main.go -algo=rr -n=3 -limiter=token -rate=10 -burst=5
 // go run main.go -algo=rr -n=3 -limiter=fixed -rate=5
 // go run main.go -algo=rr -n=3 -limiter=leaky -rate=8 -burst=3
+
+// to test per-client-IP rate limiter ->
+// go run main.go -algo=rr -n=3 -limiter=fixed -rate=2 -burst=2
+// $for /L %i in (1,1,6) do start /B curl -H "X-Forwarded-For: 1.2.3.4" http://localhost:8090/loadbalancer

--- a/main.go
+++ b/main.go
@@ -18,6 +18,10 @@ func main() {
 	numFlag := flag.Int("n", 3, "Number of backend servers to spin up")
 	weightsFlag := flag.String("weights", "", "Comma-separated weights for each server (used with wrr)")
 
+	limiterFlag := flag.String("limiter", "none", "Rate limiter algorithm: none, token, fixed, leaky")
+	rateFlag := flag.Int("rate", 5, "Allowed number of requests per second")
+	burstFlag := flag.Int("burst", 5, "Burst size (only for token and leaky bucket)")
+
 	flag.Parse()
 
 	// Convert short algo names to StrategyType
@@ -70,7 +74,7 @@ func main() {
 	go loadbalancer.StartHealthChecker(serverPool, 20*time.Second)
 
 	// Start proxy server
-	loadbalancer.StartProxy(":8090", serverPool)
+	loadbalancer.StartProxy(":8090", serverPool, *limiterFlag, *rateFlag, *burstFlag)
 }
 
 // go run main.go -algo=rr -n=5
@@ -78,3 +82,7 @@ func main() {
 // go run main.go --algo=lc --n=3
 // to test LC -> $for /L %i in (1,1,20) do start /B curl http://localhost:8090/loadbalancer
 // go run main.go --algo=ip --n=3
+
+// go run main.go -algo=rr -n=3 -limiter=token -rate=10 -burst=5
+// go run main.go -algo=rr -n=3 -limiter=fixed -rate=5
+// go run main.go -algo=rr -n=3 -limiter=leaky -rate=8 -burst=3

--- a/ratelimiter/fixed_window.go
+++ b/ratelimiter/fixed_window.go
@@ -1,0 +1,38 @@
+package ratelimiter
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+type FixedWindow struct {
+	rate      int // max #requests allowed in a window 
+	count     int // tracks #requests in one time window
+	startTime time.Time
+	mutex     sync.Mutex
+}
+
+func NewFixedWindow(rate int) *FixedWindow {
+	return &FixedWindow{
+		rate:      rate,
+		startTime: time.Now(),
+	}
+}
+
+func (fw *FixedWindow) Allow(r *http.Request) bool {
+	fw.mutex.Lock()
+	defer fw.mutex.Unlock()
+
+	now := time.Now()
+	if now.Sub(fw.startTime) > time.Second {
+		fw.startTime = now
+		fw.count = 0
+	}
+
+	if fw.count < fw.rate {
+		fw.count++
+		return true
+	}
+	return false
+}

--- a/ratelimiter/leaky_bucket.go
+++ b/ratelimiter/leaky_bucket.go
@@ -1,0 +1,43 @@
+package ratelimiter
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+type LeakyBucket struct {
+	capacity  int // max #requests bucket can hold
+	rate      float64 // allowed rate at which requests can be processed
+	water     float64 // current #requests in bucket
+	lastCheck time.Time
+	mutex     sync.Mutex
+}
+
+func NewLeakyBucket(rate int, capacity int) *LeakyBucket {
+	return &LeakyBucket{
+		capacity:  capacity,
+		rate:      float64(rate),
+		lastCheck: time.Now(),
+	}
+}
+
+func (lb *LeakyBucket) Allow(r *http.Request) bool {
+	lb.mutex.Lock()
+	defer lb.mutex.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(lb.lastCheck).Seconds()
+	lb.lastCheck = now
+
+	lb.water -= elapsed * lb.rate
+	if lb.water < 0 {
+		lb.water = 0
+	}
+
+	if lb.water < float64(lb.capacity) {
+		lb.water++
+		return true
+	}
+	return false
+}

--- a/ratelimiter/limiter.go
+++ b/ratelimiter/limiter.go
@@ -1,0 +1,20 @@
+package ratelimiter
+
+import "net/http"
+
+type Limiter interface {
+	Allow(r *http.Request) bool
+}
+
+func NewLimiter(algo string, rate int, burst int) Limiter {
+	switch algo {
+	case "token":
+		return NewTokenBucket(rate, burst)
+	case "fixed":
+		return NewFixedWindow(rate)
+	case "leaky":
+		return NewLeakyBucket(rate, burst)
+	default:
+		return nil
+	}
+}

--- a/ratelimiter/token_bucket.go
+++ b/ratelimiter/token_bucket.go
@@ -1,0 +1,45 @@
+package ratelimiter
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+type TokenBucket struct {
+	capacity int // equal to burst
+	tokens   int // available to use in bucket
+	rate     int
+	last     time.Time
+	mutex    sync.Mutex
+}
+
+func NewTokenBucket(rate int, capacity int) *TokenBucket {
+	return &TokenBucket{
+		capacity: capacity,
+		tokens:   capacity,
+		rate:     rate,
+		last:     time.Now(),
+	}
+}
+
+func (tb *TokenBucket) Allow(r *http.Request) bool {
+	tb.mutex.Lock()
+	defer tb.mutex.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(tb.last).Seconds()
+	tb.last = now
+
+	// Refill tokens based on elapsed time
+	tb.tokens += int(elapsed * float64(tb.rate))
+	if tb.tokens > tb.capacity {
+		tb.tokens = tb.capacity
+	}
+
+	if tb.tokens > 0 {
+		tb.tokens--
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Implementation of rate limiter is done, more specifically per-client-ip rate limiter. I have chosen to go with this instead of global rate limiter so that "abuse" by one IP won’t block others.
Have made 3 types of rate limiting: token bucket, leaky bucket, fixed window.